### PR TITLE
Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ powerful APIs that allow you to send, receive, track and store email effortlessl
 This client only does send at the moment. Feel free to add extra goodness.
 
   [mailgun]: http://www.mailgun.net
+  
+The URL you will need to supply is the URL to send messages for your Mailgun domain - it will look something like `https://api.mailgun.net/v2/yourdomain/messages`.
 
 ## Usage
 	import mailgun


### PR DESCRIPTION
I added a note to your README about what the URL should look like, which should make things clearer to someone who has their API URL but has no idea what they'd need to actually pass in (the root URL you get from Mailgun won't work, for example).
